### PR TITLE
Changed BaseURL to .org

### DIFF
--- a/MHacks/APIManager.swift
+++ b/MHacks/APIManager.swift
@@ -26,9 +26,9 @@ private let archiveLocation = container.appendingPathComponent("manager.plist")
 final class APIManager
 {
 	#if DEBUG
-		private static let baseURL = URL(string: "https://staging.mhacks.com")!
+		private static let baseURL = URL(string: "https://staging.mhacks.org")!
 	#else
-		private static let baseURL = URL(string: "https://mhacks.com")!
+		private static let baseURL = URL(string: "https://mhacks.org")!
 	#endif
 	
 	// MARK: - Initializers


### PR DESCRIPTION
### What

mhacks.com redirects to mhacks.org so that wasn't an issue besides an unnecessary redirect. However, in debug mode we used staging.mhacks.com which does not redirect to staging.mhacks.org.
### How

changed baseURL from .com to org

@russellladd @manavgabhawala 
